### PR TITLE
HSTS and other security headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file lists all changes to this project, grouped by versions that follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). This file is based on the format set forward by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- Security headers with Flask-Talisman, including HSTS
+- Custom Content-Security-Policy header that allows unsafe-inline style-src
+  and connect-src for relevant ws:// and wss:// headers
+
 ## [0.6.2] - 2020-03-10
 
 ### Added

--- a/be/app/__init__.py
+++ b/be/app/__init__.py
@@ -18,7 +18,7 @@ CSP_POLICY = {
     "default-src": [
         "'self'",
     ],
-    "connect-src": ["'self'", "ws://localhost:3000"],
+    "connect-src": ["'self'", "ws://localhost:3000", "wss://strate.gg:3000"],
     "style-src": ["'self'", "'unsafe-inline'"],
 }
 talisman = Talisman()

--- a/be/app/__init__.py
+++ b/be/app/__init__.py
@@ -6,6 +6,7 @@ import redis
 from flask import current_app
 from flask import Flask
 from flask_session import Session
+from flask_talisman import Talisman
 
 from app import challenges
 from app import main
@@ -13,6 +14,7 @@ from app import users
 
 
 socketio = sckt.SocketIO()
+talisman = Talisman()
 sess = Session()
 
 
@@ -32,6 +34,7 @@ def create_app(redis_instance=None):
     sess.init_app(app)
     # NOTE: fill security hole with Flask-Session default serializer being pickle
     app.session_interface.serializer = json
+    talisman.init_app(app)
     socketio.init_app(
         app,
         async_mode="eventlet",

--- a/be/app/__init__.py
+++ b/be/app/__init__.py
@@ -14,6 +14,13 @@ from app import users
 
 
 socketio = sckt.SocketIO()
+CSP_POLICY = {
+    "default-src": [
+        "'self'",
+    ],
+    "connect-src": ["'self'", "ws://localhost:3000"],
+    "style-src": ["'self'", "'unsafe-inline'"],
+}
 talisman = Talisman()
 sess = Session()
 
@@ -34,7 +41,7 @@ def create_app(redis_instance=None):
     sess.init_app(app)
     # NOTE: fill security hole with Flask-Session default serializer being pickle
     app.session_interface.serializer = json
-    talisman.init_app(app)
+    talisman.init_app(app, content_security_policy=CSP_POLICY)
     socketio.init_app(
         app,
         async_mode="eventlet",

--- a/be/tests/integration/conftest.py
+++ b/be/tests/integration/conftest.py
@@ -1,3 +1,5 @@
+import functools
+
 import pytest
 import redislite
 
@@ -22,20 +24,39 @@ def app(test_redis):
     yield test_app
 
 
+def get_https(client, *args, **kwargs):
+    return client.get(
+        *args, base_url="https://localhost", follow_redirects=True, **kwargs
+    )
+
+
 @pytest.fixture
 def client(app):
     return app.test_client()
 
 
 @pytest.fixture
+def client_https(app):
+    client = app.test_client()
+
+    # monkey patch the test_client with a get method that defaults to the HTTPS scheme!
+    get_https_augment = functools.partial(get_https, client)
+    setattr(client, "get_https", get_https_augment)
+
+    return client
+
+
+@pytest.fixture
 def socketio_client_factory(app):
     class SocketIO_Client_Factory:
         def create():
+
+            client = app.test_client()
             # emulates the real socketio usage where we load index first
             # and then connect with socketio, and thus the server socketio
             # has access to our cookie!
-            client = app.test_client()
-            client.get("/")
+            client.get("/", base_url="https://localhost", follow_redirects=True)
+
             return socketio.test_client(app, flask_test_client=client)
 
     return SocketIO_Client_Factory

--- a/be/tests/integration/test_main_routes.py
+++ b/be/tests/integration/test_main_routes.py
@@ -4,17 +4,15 @@ import pytest
 from werkzeug.http import parse_cookie
 
 
-@pytest.mark.usefixtures("client")
-def test_index(client):
-    response = client.get("/")
+def test_index(client_https):
+    response = client_https.get_https("/")
 
     assert_response_200(response)
     assert_response_is_index_html(response)
 
 
-@pytest.mark.usefixtures("client")
-def test_static_js_bundle_route(client):
-    index_response = client.get("/")
+def test_static_js_bundle_route(client_https):
+    index_response = client_https.get_https("/")
     assert_response_200(index_response)
 
     index_html_text = index_response.data.decode("utf-8")
@@ -22,14 +20,13 @@ def test_static_js_bundle_route(client):
     js_path = js_matcher.search(index_html_text).group()
     assert js_path is not None
 
-    js_bundle_response = client.get(js_path)
+    js_bundle_response = client_https.get_https(js_path)
     assert_response_200(js_bundle_response)
     assert_response_is_bundle_js(js_bundle_response)
 
 
-@pytest.mark.usefixtures("client")
-def test_index_gives_cookies(client):
-    response = client.get("/")
+def test_index_gives_cookies(client_https):
+    response = client_https.get_https("/")
 
     session_cookie = get_session_cookie_from_response(response)
 
@@ -82,7 +79,7 @@ def test_forged_cookie_is_rejected(client):
 
 
 def assert_response_200(response):
-    assert response.status == "200 OK"
+    assert response.status_code == 200
 
 
 def assert_response_is_index_html(response):

--- a/be/tests/integration/test_security_headers.py
+++ b/be/tests/integration/test_security_headers.py
@@ -1,0 +1,34 @@
+import pytest
+
+expected_security_header_pairs = [
+    ("Strict-Transport-Security", "max-age=31556926; includeSubDomains"),  # aka HSTS
+    ("Content-Security-Policy", "default-src 'self'; object-src 'none'"),
+    ("X-Content-Type-Options", "nosniff"),
+    ("X-Frame-Options", "SAMEORIGIN"),
+    ("Referrer-Policy", "strict-origin-when-cross-origin"),
+]
+
+
+@pytest.mark.parametrize("header_key,header_val", expected_security_header_pairs)
+def test_index_gives_cookies(client_https, header_key, header_val):
+    response = client_https.get_https("/")
+
+    assert header_val in get_header_from_response_by_name(response, header_key)
+
+
+def test_http_requests_returns_status_code_302(client):
+    response = client.get("/")
+    assert response.status_code == 302
+
+
+def test_http_requests_get_redirected_to_https(client):
+    response = client.get("/", follow_redirects=True)
+    assert len(response.history) == 1  # there was 1 redirect
+    assert "https://localhost/" in get_header_from_response_by_name(
+        response.history[0], "Location"
+    )
+
+
+def get_header_from_response_by_name(response, header):
+    headers = response.headers.getlist(header)
+    return headers

--- a/be/tests/integration/test_security_headers.py
+++ b/be/tests/integration/test_security_headers.py
@@ -2,7 +2,11 @@ import pytest
 
 expected_security_header_pairs = [
     ("Strict-Transport-Security", "max-age=31556926; includeSubDomains"),  # aka HSTS
-    ("Content-Security-Policy", "default-src 'self'; object-src 'none'"),
+    (
+        "Content-Security-Policy",
+        "default-src 'self'; connect-src 'self' ws://localhost:3000;"
+        + " style-src 'self' 'unsafe-inline'",
+    ),
     ("X-Content-Type-Options", "nosniff"),
     ("X-Frame-Options", "SAMEORIGIN"),
     ("Referrer-Policy", "strict-origin-when-cross-origin"),

--- a/be/tests/integration/test_security_headers.py
+++ b/be/tests/integration/test_security_headers.py
@@ -4,8 +4,8 @@ expected_security_header_pairs = [
     ("Strict-Transport-Security", "max-age=31556926; includeSubDomains"),  # aka HSTS
     (
         "Content-Security-Policy",
-        "default-src 'self'; connect-src 'self' ws://localhost:3000;"
-        + " style-src 'self' 'unsafe-inline'",
+        "default-src 'self'; connect-src 'self' ws://localhost:3000"
+        + " wss://strate.gg:3000; style-src 'self' 'unsafe-inline'",
     ),
     ("X-Content-Type-Options", "nosniff"),
     ("X-Frame-Options", "SAMEORIGIN"),

--- a/docker/dev.be.Dockerfile
+++ b/docker/dev.be.Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
-FROM python:3.7-alpine
+FROM python:3.7-slim
 WORKDIR /code
 ENV FLASK_ENV=development
-RUN apk add --no-cache gcc musl-dev linux-headers
+#RUN apk add --no-cache gcc musl-dev linux-headers
 COPY ./requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 EXPOSE 8080

--- a/docker/dev.be.Dockerfile
+++ b/docker/dev.be.Dockerfile
@@ -2,7 +2,6 @@
 FROM python:3.7-slim
 WORKDIR /code
 ENV FLASK_ENV=development
-#RUN apk add --no-cache gcc musl-dev linux-headers
 COPY ./requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 EXPOSE 8080

--- a/docker/dev.fe.Dockerfile
+++ b/docker/dev.fe.Dockerfile
@@ -7,6 +7,12 @@ WORKDIR /app
 # add `/app/node_modules/.bin` to $PATH
 ENV PATH /app/node_modules/.bin:$PATH
 
+# prevent react from inlining scripts and images, so that we can
+# maintain a strict Content-Security-Policy
+# https://drag13.io/posts/react-inline-runtimer-chunk/index.html
+ENV INLINE_RUNTIME_CHUNK=false
+ENV IMAGE_INLINE_SIZE_LIMIT=0
+
 # add app (incl. dependencies)
 COPY ./fe/package.json ./
 COPY ./fe/package-lock.json ./

--- a/docker/prod.be.Dockerfile
+++ b/docker/prod.be.Dockerfile
@@ -24,12 +24,11 @@ RUN npm run build
 
 
 # Build step #2: run the Python back end
-FROM python:3.7-alpine
+FROM python:3.7-slim
 
 WORKDIR /code
 
 ENV FLASK_ENV debug
-RUN apk add --no-cache gcc musl-dev linux-headers
 COPY ./requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 EXPOSE 8080

--- a/docker/prod.be.Dockerfile
+++ b/docker/prod.be.Dockerfile
@@ -1,9 +1,16 @@
 # syntax=docker/dockerfile:1
 # Build step #1: build the React front end
 FROM node:16.14.0-alpine as build-step
+
 WORKDIR /app
+
 ENV PATH /app/node_modules/.bin:$PATH
 
+# prevent react from inlining scripts and images, so that we can
+# maintain a strict Content-Security-Policy
+# https://drag13.io/posts/react-inline-runtimer-chunk/index.html
+ENV INLINE_RUNTIME_CHUNK=false
+ENV IMAGE_INLINE_SIZE_LIMIT=0
 
 COPY ./fe/package.json ./
 COPY ./fe/package-lock.json ./

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ filelock==3.6.0
 Flask==2.0.3
 Flask-Session==0.4.0
 Flask-SocketIO==5.1.1
+flask-talisman==0.8.1
 greenlet==1.1.2
 identify==2.4.11
 idna==3.3


### PR DESCRIPTION
- Security headers with Flask-Talisman, including HSTS
- Custom Content-Security-Policy header that allows unsafe-inline style-src
  and connect-src for relevant ws:// and wss:// headers