### PR TITLE
replace sending static file logic to load the file into memory first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@
 # https://stackoverflow.com/a/70572654
 
 # Use SYSTEM_PYTHON to create venv
-SYSTEM_PYTHON  = $(or $(shell which python3), $(shell which python))
+# python3.7 works, however, BE tests break in python3.10
+# since the project is migrating away from using Python in the backend and
+# end-of-support for py3.7 is on 2023-06-27, I am simply hard-coding py3.7 until
+# then
+SYSTEM_PYTHON  = $(or $(shell which python3.7), $(shell which python3.7))
 
 # REPOSITORY SET-UP
 # -----------------------------------------------------------------------------
@@ -46,7 +50,7 @@ test: fest best
 fest: deps-fe
 	(cd fe && npm run test)
 best: deps-py gen-secret compile-client
-	(. venv/bin/activate && cd be && python -m pytest)
+	(. venv/bin/activate && cd be && ../venv/bin/python -m pytest)
 
 jest: deps-fe # runs in watch mode
 	(cd fe && npm run jest)

--- a/be/app/main/main_routes.py
+++ b/be/app/main/main_routes.py
@@ -28,11 +28,15 @@ def serve(path):
 
 
 def serve_http_request_from_build_client_files(path):
-    if path != "" and os.path.exists(current_app.static_folder + "/" + path):
-        return send_from_directory(current_app.static_folder, path)
-    else:
-        return send_from_directory(current_app.static_folder, "index.html")
+    if path == "" or not os.path.exists(os.path.join(current_app.static_folder, path)):
+        path = "index.html"
 
+    path_in_static = os.path.join(current_app.static_folder, path)
+
+    with open(path_in_static, "r") as static_file:
+        static_contents = static_file.read()
+
+    return static_contents
 
 def proxy_to_npm_development_server():  # pragma: no cover
     resp = requests.request(

--- a/be/app/main/main_routes.py
+++ b/be/app/main/main_routes.py
@@ -4,7 +4,6 @@ import requests
 from flask import current_app
 from flask import request
 from flask import Response
-from flask import send_from_directory
 
 from app.main import bp
 from app.users import user_service
@@ -37,6 +36,7 @@ def serve_http_request_from_build_client_files(path):
         static_contents = static_file.read()
 
     return static_contents
+
 
 def proxy_to_npm_development_server():  # pragma: no cover
     resp = requests.request(


### PR DESCRIPTION
fixes errors in the test suite where the static files were reported as not closed at the time of test completion, causing errors.

fixes #66 